### PR TITLE
send verificationId in body of verifyEmail POST request else 403 error

### DIFF
--- a/lib/PassportClient.js
+++ b/lib/PassportClient.js
@@ -1939,11 +1939,17 @@ PassportClient.prototype = {
    * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
    */
   verifyEmail: function(verificationId, callBack) {
-      return this._start()
-          .uri('/api/user/verify-email')
-          .urlSegment(verificationId)
-          .post()
-          .go(callBack);
+    //If the verificationId is *only* in the URL; the response will be Error Code 403 and no response body;
+    //the verificationId must (also?) be in the body of the POST request
+      var restClient = this._start()
+                              .uri('/api/user/verify-email')
+                              .urlSegment(verificationId)
+                              .post();
+    
+      //the verificationId must (also?) be in the body of the POST request
+      restClient.body = verificationId;
+      return restClient
+            .go(callBack);
   },
 
   /**


### PR DESCRIPTION
Maybe I was making some other different mistake? 
    //If the verificationId is *only* in the URL; the response will be Error Code 403 and no response body;
    //the verificationId must (also?) be in the body of the POST request

Submitting pull request in case this is legitimate